### PR TITLE
Fix tensor shape check in MPPI controller to ensure proper batch size…

### DIFF
--- a/torchcontrol/controllers/mppi.py
+++ b/torchcontrol/controllers/mppi.py
@@ -75,7 +75,7 @@ class MPPI(ControllerBase):
         # extend the parameters batch size if they are tensors
         if hasattr(rollout_plant_cfg, "params") and rollout_plant_cfg.params is not None:
             for k, v in rollout_plant_cfg.params.__dict__.items():
-                if isinstance(v, torch.Tensor) and v.shape[0] == self.num_envs:
+                if isinstance(v, torch.Tensor) and v.ndim > 0 and v.shape[0] == self.num_envs:
                     setattr(rollout_plant_cfg.params, k, v.repeat_interleave(self.K, dim=0))
         self._rollout_plant = rollout_plant_cfg.class_type(rollout_plant_cfg)  # Create a new plant instance for rollouts
 


### PR DESCRIPTION
This pull request includes a small update to the `__init__` method in `torchcontrol/controllers/mppi.py`. The change adds a condition to check the number of dimensions (`ndim > 0`) for tensor parameters before extending their batch size.